### PR TITLE
Feature/015 Компонент секции с заголовком и датой для страницы с результатами

### DIFF
--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -25,3 +25,19 @@ export const formatDateShort = (dateString: string): string => {
     year: 'numeric',
   });
 };
+
+export const isValidDate = (value: string) => {
+  const dateFormat = /^(\d{4})-(\d{2})-(\d{2})$/;
+  const isDateFormat: boolean = dateFormat.test(value);
+  console.log(isDateFormat);
+  if (!isDateFormat) return false;
+  const [year, month, day] = value.split('-').map(Number);
+  console.log([year, month, day]);
+  const date = new Date(year, month - 1, day);
+  console.log(date);
+  return (
+    date.getFullYear() === year &&
+    date.getMonth() === month - 1 &&
+    date.getDate() === day
+  );
+};

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -29,12 +29,9 @@ export const formatDateShort = (dateString: string): string => {
 export const isValidDate = (value: string) => {
   const dateFormat = /^(\d{4})-(\d{2})-(\d{2})$/;
   const isDateFormat: boolean = dateFormat.test(value);
-  console.log(isDateFormat);
   if (!isDateFormat) return false;
   const [year, month, day] = value.split('-').map(Number);
-  console.log([year, month, day]);
   const date = new Date(year, month - 1, day);
-  console.log(date);
   return (
     date.getFullYear() === year &&
     date.getMonth() === month - 1 &&

--- a/src/pages/Result/components/titleSectionResult/TitleSectionResult.module.css
+++ b/src/pages/Result/components/titleSectionResult/TitleSectionResult.module.css
@@ -4,7 +4,7 @@
   align-items: center;
   gap: 12px;
   width: 100%;
-  color: var(--main-text-color, #141414);
+  color: var(--text-main-color, #141414);
 }
 
 .title {

--- a/src/pages/Result/components/titleSectionResult/TitleSectionResult.module.css
+++ b/src/pages/Result/components/titleSectionResult/TitleSectionResult.module.css
@@ -1,0 +1,41 @@
+.section {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 12px;
+  width: 100%;
+  color: var(--main-text-color, #141414);
+}
+
+.title {
+  font: var(--font-h1);
+}
+
+.date {
+  font: var(--font-body-20);
+}
+
+/* стили для планшетной версии */
+@media (834px <= width < 1200px) {
+  .title {
+    font: var(--font-h1-tablet);
+    font-size: 36px;
+  }
+}
+
+/* cтили для мобильной версии */
+@media (width < 834px) {
+  .section {
+    flex-direction: column;
+  }
+
+  .title {
+    font: var(--font-h1-mobile);
+    text-align: start;
+  }
+
+  .date {
+    text-align: end;
+    align-self: flex-end;
+  }
+}

--- a/src/pages/Result/components/titleSectionResult/TitleSectionResult.module.css
+++ b/src/pages/Result/components/titleSectionResult/TitleSectionResult.module.css
@@ -32,6 +32,7 @@
   .title {
     font: var(--font-h1-mobile);
     text-align: start;
+    align-self: flex-start;
   }
 
   .date {

--- a/src/pages/Result/components/titleSectionResult/TitleSectionResult.tsx
+++ b/src/pages/Result/components/titleSectionResult/TitleSectionResult.tsx
@@ -4,7 +4,7 @@ import { formatDateShort, isValidDate } from '../../../../lib/utils';
 
 type TTitleSectionResult = {
   className?: string;
-  reportDate?: string;
+  reportDate?: string; // ожидаемый формат 'гггг-мм-дд'
 };
 
 export const TitleSectionResult: React.FC<TTitleSectionResult> = ({

--- a/src/pages/Result/components/titleSectionResult/TitleSectionResult.tsx
+++ b/src/pages/Result/components/titleSectionResult/TitleSectionResult.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import styles from './TitleSectionResult.module.css';
-import { formatDateShort } from '../../../../lib/utils';
+import { formatDateShort, isValidDate } from '../../../../lib/utils';
 
 type TTitleSectionResult = {
   className?: string;
@@ -11,9 +11,11 @@ export const TitleSectionResult: React.FC<TTitleSectionResult> = ({
   className,
   reportDate,
 }) => {
-  const formattedReportDate: string = reportDate
-    ? formatDateShort(reportDate)
-    : formatDateShort(String(new Date()));
+  /* если дата не передана с бэкэнда или передана в неверном формате, то указывается текущая дата */
+  const formattedReportDate: string =
+    reportDate && isValidDate(reportDate)
+      ? formatDateShort(reportDate)
+      : formatDateShort(String(new Date()));
   return (
     <section
       className={className ? `${className} ${styles.section}` : styles.section}

--- a/src/pages/Result/components/titleSectionResult/TitleSectionResult.tsx
+++ b/src/pages/Result/components/titleSectionResult/TitleSectionResult.tsx
@@ -1,0 +1,25 @@
+import React from 'react';
+import styles from './TitleSectionResult.module.css';
+import { formatDateShort } from '../../../../lib/utils';
+
+type TTitleSectionResult = {
+  className?: string;
+  reportDate?: string;
+};
+
+export const TitleSectionResult: React.FC<TTitleSectionResult> = ({
+  className,
+  reportDate,
+}) => {
+  const formattedReportDate: string = reportDate
+    ? formatDateShort(reportDate)
+    : formatDateShort(String(new Date()));
+  return (
+    <section
+      className={className ? `${className} ${styles.section}` : styles.section}
+    >
+      <h1 className={styles.title}>Результат расчёта динамики</h1>
+      <span className={styles.date}>{formattedReportDate + ' г.'}</span>
+    </section>
+  );
+};

--- a/src/pages/Result/components/titleSectionResult/index.ts
+++ b/src/pages/Result/components/titleSectionResult/index.ts
@@ -1,0 +1,1 @@
+export { TitleSectionResult } from './TitleSectionResult';


### PR DESCRIPTION
В пропсах компонента можно передать className для стилизации (в том числе расположения компонента) на странице с результатами.
Также компонент принимает с бэкенда дату заполнения отчета, а если ее нет, то указывается текущая дата.

Ссылка на задачу: https://github.com/Caritas-Team/Frontend/issues/15