### PR TITLE
Feature/7 Изменены размеры Logo для мобильной версии

### DIFF
--- a/src/ui/logo/styles.module.css
+++ b/src/ui/logo/styles.module.css
@@ -5,7 +5,8 @@
 
 @media (max-width: 833px) {
   .logo {
-    width: 132px;
-    height: 47px;
+    width: 81px;
+    height: 30px;
+    margin-top: 8px;
   }
 }


### PR DESCRIPTION
В связи с правками в макете изменился размер компонента Logo в мобильной версии.

Внесла изменения в компонент с разрешения Сергея.
Так как компонент не предусматривает передачу className в пропсах, то для позиционирования в соответствии с макетом указала также margin-top.